### PR TITLE
Rename Close to CloseWindow

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -20,7 +20,7 @@ pub enum WebDriverCommand<T: WebDriverExtensionCommand> {
     GetPageSource,
     GetWindowHandle,
     GetWindowHandles,
-    Close,
+    CloseWindow,
     GetWindowSize,
     SetWindowSize(WindowSizeParameters),
     GetWindowPosition,
@@ -124,7 +124,7 @@ impl <U: WebDriverExtensionRoute> WebDriverMessage<U> {
             Route::GetPageSource => WebDriverCommand::GetPageSource,
             Route::GetWindowHandle => WebDriverCommand::GetWindowHandle,
             Route::GetWindowHandles => WebDriverCommand::GetWindowHandles,
-            Route::Close => WebDriverCommand::Close,
+            Route::CloseWindow => WebDriverCommand::CloseWindow,
             Route::SetTimeouts => {
                 let parameters: TimeoutsParameters = try!(Parameters::from_json(&body_data));
                 WebDriverCommand::SetTimeouts(parameters)
@@ -344,7 +344,7 @@ impl <U:WebDriverExtensionRoute> ToJson for WebDriverMessage<U> {
             WebDriverCommand::GetPageSource |
             WebDriverCommand::GetWindowHandle |
             WebDriverCommand::GetWindowHandles |
-            WebDriverCommand::Close |
+            WebDriverCommand::CloseWindow |
             WebDriverCommand::GetWindowSize |
             WebDriverCommand::GetWindowPosition |
             WebDriverCommand::MaximizeWindow |

--- a/src/httpapi.rs
+++ b/src/httpapi.rs
@@ -20,7 +20,7 @@ fn standard_routes<U:WebDriverExtensionRoute>() -> Vec<(Method, &'static str, Ro
                 (Get, "/session/{sessionId}/source", Route::GetPageSource),
                 (Get, "/session/{sessionId}/window", Route::GetWindowHandle),
                 (Get, "/session/{sessionId}/window/handles", Route::GetWindowHandles),
-                (Delete, "/session/{sessionId}/window", Route::Close),
+                (Delete, "/session/{sessionId}/window", Route::CloseWindow),
                 (Get, "/session/{sessionId}/window/size", Route::GetWindowSize),
                 (Post, "/session/{sessionId}/window/size", Route::SetWindowSize),
                 (Get, "/session/{sessionId}/window/position", Route::GetWindowPosition),
@@ -69,7 +69,7 @@ fn standard_routes<U:WebDriverExtensionRoute>() -> Vec<(Method, &'static str, Ro
                 (Post, "/session/{sessionId}/dismiss_alert", Route::DismissAlert),
                 (Get, "/session/{sessionId}/window_handle", Route::GetWindowHandle),
                 (Get, "/session/{sessionId}/window_handles", Route::GetWindowHandles),
-                (Delete, "/session/{sessionId}/window_handle", Route::Close),
+                (Delete, "/session/{sessionId}/window_handle", Route::CloseWindow),
                 (Post, "/session/{sessionId}/execute_async", Route::ExecuteAsyncScript),
                 (Post, "/session/{sessionId}/execute", Route::ExecuteScript),]
 }
@@ -87,7 +87,7 @@ pub enum Route<U:WebDriverExtensionRoute> {
     GetPageSource,
     GetWindowHandle,
     GetWindowHandles,
-    Close,
+    CloseWindow,
     GetWindowSize,
     SetWindowSize,
     GetWindowPosition,


### PR DESCRIPTION
Close Window is the official name of the command for closing windows.
I believe it used to be called just Close some iterations ago.