### PR TITLE
Allow command Status without session id

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -119,6 +119,7 @@ impl <T: WebDriverHandler<U>,
                 match self.session {
                     Some(_) => {
                         match msg.command {
+                            WebDriverCommand::Status => Ok(()),
                             WebDriverCommand::NewSession(_) => {
                                 Err(WebDriverError::new(
                                     ErrorStatus::SessionNotCreated,


### PR DESCRIPTION
The command still throws an error if no connection is still established (`{"error":"unknown error","message":"Got a command with no session?!"}`)

I am not sure if this is what completes the work on the `webdriver-rust` side. With [this implemented in geckodriver](https://github.com/mozilla/geckodriver/compare/master...vkatsikaros:286/status_endpoint) I still get a `{"error":"unknown command","message":"status"}`

References #45 
