### PR TITLE
Correct response headers

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,8 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Mutex;
 use std::thread;
 
-use hyper::header::ContentType;
+use hyper::header::{ContentType, CacheControl, CacheDirective};
+use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
 use hyper::method::Method;
 use hyper::Result;
 use hyper::server::{Handler, Listening, Request, Response, Server};
@@ -223,7 +224,10 @@ impl <U: WebDriverExtensionRoute> Handler for HttpHandler<U> {
                     let resp_status = res.status_mut();
                     *resp_status = status;
                 }
-                res.headers_mut().set(ContentType::json());
+                res.headers_mut().set(
+                    ContentType(Mime(TopLevel::Application, SubLevel::Json,
+                                     vec![(Attr::Charset, Value::Utf8)])));
+                res.headers_mut().set(CacheControl(vec![CacheDirective::NoCache]));
                 res.send(&resp_body.as_bytes()).unwrap();
             },
             _ => {}


### PR DESCRIPTION
> ## 5.3 Processing Model
>
> [...]
>
> When required to send a response, with arguments status and data, a
> remote end must run the following steps:
>
> [...]
> 3. Set the response's header with name and value with the following
>    values:
>
>    "Content-Type"
>        "application/json; charset=utf-8"
>    "cache-control"
>        "no-cache"

Source: https://w3c.github.io/webdriver/webdriver-spec.html#dfn-send-a-response

Please note: I have not yet been able to test this patch locally.