### PR TITLE
Delete session on last window

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -167,35 +167,30 @@ impl Error for WebDriverError {
 
 impl From<ParserError> for WebDriverError {
     fn from(err: ParserError) -> WebDriverError {
-        WebDriverError::new(ErrorStatus::UnknownError,
-            err.description().to_string())
+        WebDriverError::new(ErrorStatus::UnknownError, err.description().to_string())
     }
 }
 
 impl From<IoError> for WebDriverError {
     fn from(err: IoError) -> WebDriverError {
-        WebDriverError::new(ErrorStatus::UnknownError,
-            err.description().to_string())
+        WebDriverError::new(ErrorStatus::UnknownError, err.description().to_string())
     }
 }
 
 impl From<DecoderError> for WebDriverError {
     fn from(err: DecoderError) -> WebDriverError {
-        WebDriverError::new(ErrorStatus::UnknownError,
-                            err.description().to_string())
+        WebDriverError::new(ErrorStatus::UnknownError, err.description().to_string())
     }
 }
 
 impl From<FromBase64Error> for WebDriverError {
     fn from(err: FromBase64Error) -> WebDriverError {
-        WebDriverError::new(ErrorStatus::UnknownError,
-                            err.description().to_string())
+        WebDriverError::new(ErrorStatus::UnknownError, err.description().to_string())
     }
 }
 
 impl From<Box<Error>> for WebDriverError {
     fn from(err: Box<Error>) -> WebDriverError {
-        WebDriverError::new(ErrorStatus::UnknownError,
-                            err.description().to_string())
+        WebDriverError::new(ErrorStatus::UnknownError, err.description().to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ pub type WebDriverResult<T> = Result<T, WebDriverError>;
 pub struct WebDriverError {
     pub error: ErrorStatus,
     pub message: Cow<'static, str>,
-    delete_session: bool
+    pub delete_session: bool,
 }
 
 impl fmt::Display for WebDriverError {
@@ -121,7 +121,7 @@ impl WebDriverError {
         WebDriverError {
             error: error,
             message: message.into(),
-            delete_session: false
+            delete_session: false,
         }
     }
 
@@ -135,14 +135,6 @@ impl WebDriverError {
 
     pub fn to_json_string(&self) -> String {
         self.to_json().to_string()
-    }
-
-    pub fn set_delete_session(&mut self) {
-        self.delete_session = true
-    }
-
-    pub fn delete_session(&self) -> bool {
-        self.delete_session
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -7,28 +7,41 @@ use std::collections::BTreeMap;
 
 #[derive(Debug)]
 pub enum WebDriverResponse {
-    NewSession(NewSessionResponse),
-    DeleteSession,
-    WindowSize(WindowSizeResponse),
-    WindowPosition(WindowPositionResponse),
-    ElementRect(ElementRectResponse),
+    CloseWindow(CloseWindowResponse),
     Cookie(CookieResponse),
+    DeleteSession,
+    ElementRect(ElementRectResponse),
     Generic(ValueResponse),
-    Void
+    NewSession(NewSessionResponse),
+    Void,
+    WindowPosition(WindowPositionResponse),
+    WindowSize(WindowSizeResponse),
 }
 
 impl WebDriverResponse {
     pub fn to_json_string(self) -> String {
         match self {
-            WebDriverResponse::NewSession(x) => json::encode(&x),
-            WebDriverResponse::DeleteSession => Ok("{}".to_string()),
-            WebDriverResponse::WindowSize(x) => json::encode(&x),
-            WebDriverResponse::WindowPosition(x) => json::encode(&x),
-            WebDriverResponse::ElementRect(x) => json::encode(&x),
+            WebDriverResponse::CloseWindow(x) => json::encode(&x),
             WebDriverResponse::Cookie(x) => json::encode(&x),
+            WebDriverResponse::DeleteSession => Ok("{}".to_string()),
+            WebDriverResponse::ElementRect(x) => json::encode(&x),
             WebDriverResponse::Generic(x) => json::encode(&x),
-            WebDriverResponse::Void => Ok("{}".to_string())
+            WebDriverResponse::NewSession(x) => json::encode(&x),
+            WebDriverResponse::Void => Ok("{}".to_string()),
+            WebDriverResponse::WindowPosition(x) => json::encode(&x),
+            WebDriverResponse::WindowSize(x) => json::encode(&x),
         }.unwrap()
+    }
+}
+
+#[derive(RustcEncodable, Debug)]
+pub struct CloseWindowResponse {
+    pub window_handles: Vec<String>,
+}
+
+impl CloseWindowResponse {
+    pub fn new(handles: Vec<String>) -> CloseWindowResponse {
+        CloseWindowResponse { window_handles: handles }
     }
 }
 


### PR DESCRIPTION
This implements [step 4 of the Close Window steps](https://w3c.github.io/webdriver/webdriver-spec.html#dfn-close-window) that [closes the session](https://w3c.github.io/webdriver/webdriver-spec.html#dfn-close-the-session).

When the window handle array sent back from the `CloseWindow` command is empty, delete the session.

It also changes the `WebDriverError`’s API slightly by publishing the `delete_session` field instead of using the hard-to-understand `set_delete_session` and `delete_session` getter/setters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/64)
<!-- Reviewable:end -->
