### PR TITLE
Include backtrace for errors originating from Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ repository = "https://github.com/jgraham/webdriver-rust"
 license = "MPL-2.0"
 
 [dependencies]
+backtrace = "0.3"
+cookie = {version = "0.2", default-features = false}
+hyper = {version = "0.9", default-features = false}
 log = "0.3"
 regex = "0.2"
 rustc-serialize = "0.3"
-hyper = {version = "0.9", default-features = false}
-cookie = {version = "0.2", default-features = false}
 time = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+extern crate backtrace;
 #[macro_use]
 extern crate log;
 extern crate rustc_serialize;
@@ -15,7 +16,6 @@ pub mod common;
 pub mod error;
 pub mod server;
 pub mod response;
-
 
 #[cfg(test)]
 mod nullable_tests {


### PR DESCRIPTION
The WebDriver standard says the stacktrace field on error responses are
implementation-defined, but the field cannot be omitted.  The errors
originating from Marionette are passed on without modification and
include the expected stacktrace.

This exposes a backtrace from the Rust crate with the same name for the
errors originating from within the library itself.

Fixes: https://github.com/mozilla/webdriver-rust/issues/63

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/65)
<!-- Reviewable:end -->
