### PR TITLE
Align timeouts format with spec

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -522,30 +522,48 @@ impl ToJson for GetParameters {
 
 #[derive(PartialEq)]
 pub struct TimeoutsParameters {
-    pub type_: String,
-    pub ms: f64
+    pub script: Option<u64>,
+    pub page_load: Option<u64>,
+    pub implicit: Option<u64>,
 }
 
 impl Parameters for TimeoutsParameters {
     fn from_json(body: &Json) -> WebDriverResult<TimeoutsParameters> {
-        let data = try_opt!(body.as_object(), ErrorStatus::UnknownError,
+        let data = try_opt!(body.as_object(),
+                            ErrorStatus::UnknownError,
                             "Message body was not an object");
-        let type_ = try_opt!(
-            try_opt!(data.get("type"),
-                     ErrorStatus::InvalidArgument,
-                     "Missing 'type' parameter").as_string(),
-            ErrorStatus::InvalidArgument,
-            "'type' not a string");
 
-        let ms = try_opt!(
-            try_opt!(data.get("ms"),
-                     ErrorStatus::InvalidArgument,
-                     "Missing 'ms' parameter").as_f64(),
-            ErrorStatus::InvalidArgument,
-            "'ms' not a float");
-        return Ok(TimeoutsParameters {
-            type_: type_.to_string(),
-            ms: ms
+        let script = match data.get("script") {
+            Some(json) => {
+                Some(try_opt!(json.as_u64(),
+                              ErrorStatus::InvalidArgument,
+                              "Script timeout duration was not a signed integer"))
+            }
+            None => None,
+        };
+
+        let page_load = match data.get("pageLoad") {
+            Some(json) => {
+                Some(try_opt!(json.as_u64(),
+                              ErrorStatus::InvalidArgument,
+                              "Script timeout duration was not a signed integer"))
+            }
+            None => None,
+        };
+
+        let implicit = match data.get("script") {
+            Some(json) => {
+                Some(try_opt!(json.as_u64(),
+                              ErrorStatus::InvalidArgument,
+                              "Script timeout duration was not a signed integer"))
+            }
+            None => None,
+        };
+
+        Ok(TimeoutsParameters {
+            script: script,
+            page_load: page_load,
+            implicit: implicit,
         })
     }
 }
@@ -553,8 +571,15 @@ impl Parameters for TimeoutsParameters {
 impl ToJson for TimeoutsParameters {
     fn to_json(&self) -> Json {
         let mut data = BTreeMap::new();
-        data.insert("type".to_string(), self.type_.to_json());
-        data.insert("ms".to_string(), self.ms.to_json());
+        if let Some(ms) = self.script {
+            data.insert("script".into(), ms.to_json());
+        }
+        if let Some(ms) = self.page_load {
+            data.insert("pageLoad".into(), ms.to_json());
+        }
+        if let Some(ms) = self.implicit {
+            data.insert("implicit".into(), ms.to_json());
+        }
         Json::Object(data)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,6 +12,7 @@ pub enum WebDriverResponse {
     ElementRect(ElementRectResponse),
     Generic(ValueResponse),
     NewSession(NewSessionResponse),
+    Timeouts(TimeoutsResponse),
     Void,
     WindowPosition(WindowPositionResponse),
     WindowSize(WindowSizeResponse),
@@ -26,6 +27,7 @@ impl WebDriverResponse {
             WebDriverResponse::ElementRect(x) => json::encode(&x),
             WebDriverResponse::Generic(x) => json::encode(&x),
             WebDriverResponse::NewSession(x) => json::encode(&x),
+            WebDriverResponse::Timeouts(x) => json::encode(&x),
             WebDriverResponse::Void => Ok("{}".to_string()),
             WebDriverResponse::WindowPosition(x) => json::encode(&x),
             WebDriverResponse::WindowSize(x) => json::encode(&x),
@@ -57,6 +59,13 @@ impl NewSessionResponse {
             sessionId: session_id
         }
     }
+}
+
+#[derive(RustcEncodable, Debug)]
+pub struct TimeoutsResponse {
+    pub script: u64,
+    pub pageLoad: u64,
+    pub implicit: u64,
 }
 
 #[derive(RustcEncodable, Debug)]


### PR DESCRIPTION
WebDriver's timeouts configuration object format changed recently,
and this aligns us with the specification.  Fields in the JSON Object
passed to Set Timeouts as parameters are optional, meaning it is possible
to send `{"search": <u64>}` without defining "pageLoad" or "implicit".
Upon responding, the JSON Object in the body must contain all fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/72)
<!-- Reviewable:end -->
