### PR TITLE
Match on correct implicit timeout duration key

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -551,7 +551,7 @@ impl Parameters for TimeoutsParameters {
             None => None,
         };
 
-        let implicit = match data.get("script") {
+        let implicit = match data.get("implicit") {
             Some(json) => {
                 Some(try_opt!(json.as_u64(),
                               ErrorStatus::InvalidArgument,


### PR DESCRIPTION
Fixes: https://github.com/mozilla/webdriver-rust/issues/77

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/78)
<!-- Reviewable:end -->
