### PR TITLE
Fix validate_port if value is a Json::U64.

### DIFF
--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -241,8 +241,8 @@ impl SpecNewSessionParameters {
     }
 
     fn validate_port(name: &str, value: &Json) -> WebDriverResult<()> {
-        match value {
-            &Json::I64(x) => {
+        match value.as_i64() {
+            Some(x) => {
                 if x < 0 || x > 2i64.pow(16) - 1 {
                     return Err(WebDriverError::new(
                         ErrorStatus::InvalidArgument,


### PR DESCRIPTION
Should fix https://github.com/mozilla/geckodriver/issues/631.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/87)
<!-- Reviewable:end -->
