### PR TITLE
Make log output safe for windows prompt

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -173,7 +173,7 @@ impl<U: WebDriverExtensionRoute> Handler for HttpHandler<U> {
             req.read_to_string(&mut body).unwrap();
         }
 
-        debug!("→ {} {} {}", req.method, req.uri, body);
+        debug!("-> {} {} {}", req.method, req.uri, body);
 
         match req.uri {
             AbsolutePath(path) => {
@@ -218,7 +218,7 @@ impl<U: WebDriverExtensionRoute> Handler for HttpHandler<U> {
                     Err(err) => (err.http_status(), err.to_json_string()),
                 };
 
-                debug!("← {} {}", status, resp_body);
+                debug!("<- {} {}", status, resp_body);
 
                 {
                     let resp_status = res.status_mut();


### PR DESCRIPTION
The characters "←" and "→" are obfuscated in the Windows command
prompt.  Use ASCII versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/96)
<!-- Reviewable:end -->
