### PR TITLE
Don't return existing session id when the wrong one is supplied

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -105,9 +105,8 @@ impl<T: WebDriverHandler<U>, U: WebDriverExtensionRoute> Dispatcher<T, U> {
                         if existing_session.id != *msg_session_id {
                             Err(WebDriverError::new(
                                 ErrorStatus::InvalidSessionId,
-                                format!("Got unexpected session id {} expected {}",
-                                        msg_session_id,
-                                        existing_session.id)))
+                                format!("Got unexpected session id {}",
+                                        msg_session_id)))
                         } else {
                             Ok(())
                         }


### PR DESCRIPTION
Fixes #98

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/99)
<!-- Reviewable:end -->
