### PR TITLE
Implement the minimize window for webdriver-rust

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -25,6 +25,7 @@ pub enum WebDriverCommand<T: WebDriverExtensionCommand> {
     CloseWindow,
     GetWindowRect,
     SetWindowRect(WindowRectParameters),
+    MinimizeWindow,
     MaximizeWindow,
     FullscreenWindow,
     SwitchToWindow(SwitchToWindowParameters),
@@ -135,6 +136,7 @@ impl<U: WebDriverExtensionRoute> WebDriverMessage<U> {
                 let parameters: WindowRectParameters = Parameters::from_json(&body_data)?;
                 WebDriverCommand::SetWindowRect(parameters)
             },
+            Route::MinimizeWindow => WebDriverCommand::MinimizeWindow,
             Route::MaximizeWindow => WebDriverCommand::MaximizeWindow,
             Route::FullscreenWindow => WebDriverCommand::FullscreenWindow,
             Route::SwitchToWindow => {
@@ -401,6 +403,7 @@ impl <U:WebDriverExtensionRoute> ToJson for WebDriverMessage<U> {
             WebDriverCommand::IsDisplayed(_) |
             WebDriverCommand::IsEnabled(_) |
             WebDriverCommand::IsSelected(_) |
+            WebDriverCommand::MinimizeWindow |
             WebDriverCommand::MaximizeWindow |
             WebDriverCommand::FullscreenWindow |
             WebDriverCommand::NewSession(_) |

--- a/src/httpapi.rs
+++ b/src/httpapi.rs
@@ -27,6 +27,7 @@ fn standard_routes<U:WebDriverExtensionRoute>() -> Vec<(Method, &'static str, Ro
                 (Post, "/session/{sessionId}/window/position", Route::SetWindowPosition),
                 (Get, "/session/{sessionId}/window/rect", Route::GetWindowRect),
                 (Post, "/session/{sessionId}/window/rect", Route::SetWindowRect),
+                (Post, "/session/{sessionId}/window/minimize", Route::MinimizeWindow),
                 (Post, "/session/{sessionId}/window/maximize", Route::MaximizeWindow),
                 (Post, "/session/{sessionId}/window/fullscreen", Route::FullscreenWindow),
                 (Post, "/session/{sessionId}/window", Route::SwitchToWindow),
@@ -90,6 +91,7 @@ pub enum Route<U:WebDriverExtensionRoute> {
     SetWindowPosition,  // deprecated
     GetWindowRect,
     SetWindowRect,
+    MinimizeWindow,
     MaximizeWindow,
     FullscreenWindow,
     SwitchToWindow,


### PR DESCRIPTION
Symptom: Now webdriver-rust cannot minimize window
Root Cause: No minimize command
Solution: Add the minimize command
Project: webdriver-rust
Note: After add this patch
      Then add one in geckodriver
      Then add support in firefox(marionette)
      At last add patch in selenium(firefox webdriver)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/105)
<!-- Reviewable:end -->
