### PR TITLE
common, response: add window state to window rect response

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -189,14 +189,14 @@ pub enum LocatorStrategy {
     CSSSelector,
     LinkText,
     PartialLinkText,
-    XPath
+    XPath,
 }
 
 impl LocatorStrategy {
     pub fn from_json(body: &Json) -> WebDriverResult<LocatorStrategy> {
         match try_opt!(body.as_string(),
                        ErrorStatus::InvalidArgument,
-                       "Cound not convert strategy to string") {
+                       "Expected locator strategy as string") {
             "css selector" => Ok(LocatorStrategy::CSSSelector),
             "link text" => Ok(LocatorStrategy::LinkText),
             "partial link text" => Ok(LocatorStrategy::PartialLinkText),
@@ -215,5 +215,57 @@ impl ToJson for LocatorStrategy {
             LocatorStrategy::PartialLinkText => "partial link text",
             LocatorStrategy::XPath => "xpath"
         }.to_string())
+    }
+}
+
+/// The top-level browsing context has an associated window state which
+/// describes what visibility state its OS widget window is in.
+///
+/// The default state is [`Normal`].
+///
+/// [`normal`]: #variant.Normal
+#[derive(Debug)]
+pub enum WindowState {
+    /// The window is maximized.
+    Maximized,
+    /// The window is iconified.
+    Minimized,
+    /// The window is shown normally.
+    Normal,
+    /// The window is in full screen mode.
+    Fullscreen,
+}
+
+impl WindowState {
+    pub fn from_json(body: &Json) -> WebDriverResult<WindowState> {
+        use self::WindowState::*;
+        let s = try_opt!(
+            body.as_string(),
+            ErrorStatus::InvalidArgument,
+            "Expecetd window state as string"
+        );
+        match s {
+            "maximized" => Ok(Maximized),
+            "minimized" => Ok(Minimized),
+            "normal" => Ok(Normal),
+            "fullscreen" => Ok(Fullscreen),
+            x => Err(WebDriverError::new(
+                ErrorStatus::InvalidArgument,
+                format!("Unknown window state {}", x),
+            )),
+        }
+    }
+}
+
+impl ToJson for WindowState {
+    fn to_json(&self) -> Json {
+        use self::WindowState::*;
+        let state = match *self {
+            Maximized => "maximized",
+            Minimized => "minimized",
+            Normal => "normal",
+            Fullscreen => "fullscreen",
+        };
+        Json::String(state.to_string())
     }
 }


### PR DESCRIPTION
The WebDriver specification recently introduced an additional "state"
field for the window rect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/109)
<!-- Reviewable:end -->
