### PR TITLE
Add Tag Name as a valid location strategy.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -189,6 +189,7 @@ pub enum LocatorStrategy {
     CSSSelector,
     LinkText,
     PartialLinkText,
+    TagName,
     XPath,
 }
 
@@ -200,6 +201,7 @@ impl LocatorStrategy {
             "css selector" => Ok(LocatorStrategy::CSSSelector),
             "link text" => Ok(LocatorStrategy::LinkText),
             "partial link text" => Ok(LocatorStrategy::PartialLinkText),
+            "tag name" => Ok(LocatorStrategy::TagName),
             "xpath" => Ok(LocatorStrategy::XPath),
             x => Err(WebDriverError::new(ErrorStatus::InvalidArgument,
                                          format!("Unknown locator strategy {}", x)))
@@ -213,6 +215,7 @@ impl ToJson for LocatorStrategy {
             LocatorStrategy::CSSSelector => "css selector",
             LocatorStrategy::LinkText => "link text",
             LocatorStrategy::PartialLinkText => "partial link text",
+            LocatorStrategy::TagName => "tag name",
             LocatorStrategy::XPath => "xpath"
         }.to_string())
     }


### PR DESCRIPTION
While creating WDSpec for Find Element and similar commands it showed
that we do not support Tag Name as a valid selector. Tests can be found
at https://reviewboard.mozilla.org/r/172110/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/webdriver-rust/118)
<!-- Reviewable:end -->
